### PR TITLE
Added vegdist to bluster hclust

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,10 @@ Description:
 Authors@R: 
     c(
         person("Aaron", "Lun", role = c("aut", "cre"), email = "infinite.monkeys.with.keyboards@gmail.com"),
-        person("Stephanie", "Hicks", role="ctb")
+        person("Stephanie", "Hicks", role="ctb"),
+        person("Basil", "Courbayre", role="ctb"),
+        person("Tuomas", "Borman", role="ctb"),
+        person("Leo", "Lahti", role="ctb")
     )
 Imports: 
     stats, 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bluster
-Version: 1.9.1
-Date: 2023-01-12
+Version: 1.9.2
+Date: 2023-05-26
 Title: Clustering Algorithms for Bioconductor
 Description: 
     Wraps common clustering algorithms in an easily extended S4 framework.
@@ -36,7 +36,8 @@ Suggests:
     viridis,
     mbkmeans,
     kohonen,
-    apcluster
+    apcluster,
+    vegan
 biocViews: 
     ImmunoOncology, 
     Software, 

--- a/R/AllClasses.R
+++ b/R/AllClasses.R
@@ -73,6 +73,7 @@ setClass("FixedNumberParam", contains=c("BlusterParam", "VIRTUAL"), slots=c(cent
 #' @section Available slots:
 #' The virtual class provides \code{metric}, the choice of distance metric.
 #' This is conventionally passed to \code{\link{dist}} and defaults to a Euclidean distance in most subclasses.
+#' The distance function can be changed with the parameter \code{dist.fun}.
 #'
 #' It also provides a number of slots to manage the final tree cut:
 #' \itemize{
@@ -102,6 +103,7 @@ setClass("FixedNumberParam", contains=c("BlusterParam", "VIRTUAL"), slots=c(cent
 setClass("HierarchicalParam", contains=c("BlusterParam", "VIRTUAL"), 
     slots=c(
         metric="ANY",
+        dist.fun="function_OR_NULL", 
         cut.fun="function_OR_NULL", 
         cut.dynamic="logical", 
         cut.params="list"

--- a/R/HclustParam.R
+++ b/R/HclustParam.R
@@ -3,7 +3,7 @@
 #' Run the base \code{\link{hclust}} function on a distance matrix within \code{\link{clusterRows}}.
 #'
 #' @param metric String specifying the distance metric to use in \code{\link{dist}}.
-#' @param dist.fun Function specifying the function to use to compute the distance matrix.
+#' @param dist.fun Function specifying the function to use to compute the distance matrix. Must be stats::dist-like function. i.e. takes a method as a parameter and returns a dissimilarity matrix.
 #' @param method String specifying the agglomeration method to use in \code{\link{hclust}}.
 #' @param cut.fun Function specifying the method to use to cut the dendrogram.
 #' The first argument of this function should be the output of \code{\link{hclust}},
@@ -26,7 +26,7 @@
 #' If \code{cut.fun=NULL}, \code{cut.dynamic=FALSE} and \code{cut.params} does not have \code{h} or \code{k},
 #' \code{\link{clusterRows}} will automatically set \code{h} to half the tree height when calling \code{\link{cutree}}. 
 #'
-#' @return 
+#' @return
 #' The \code{HclustParam} constructor will return a \linkS4class{HclustParam} object with the specified parameters.
 #'
 #' The \code{clusterRows} method will return a factor of length equal to \code{nrow(x)} containing the cluster assignments.

--- a/R/HclustParam.R
+++ b/R/HclustParam.R
@@ -36,6 +36,7 @@
 #' @examples
 #' clusterRows(iris[,1:4], HclustParam())
 #' clusterRows(iris[,1:4], HclustParam(method="ward.D2"))
+#' clusterRows(iris[,1:4], HclustParam(metric = "canberra", dist.fun = vegan::vegdist))
 #'
 #' @seealso
 #' \code{\link{dist}}, \code{\link{hclust}} and \code{\link{cutree}}, which actually do all the heavy lifting.

--- a/man/HclustParam-class.Rd
+++ b/man/HclustParam-class.Rd
@@ -28,7 +28,7 @@ HclustParam(
 \arguments{
 \item{metric}{String specifying the distance metric to use in \code{\link{dist}}.}
 
-\item{dist.fun}{Function specifying the function to use to compute the distance matrix.}
+\item{dist.fun}{Function specifying the function to use to compute the distance matrix. Must be stats::dist-like function. i.e. takes a method as a parameter and returns a dissimilarity matrix.}
 
 \item{method}{String specifying the agglomeration method to use in \code{\link{hclust}}.}
 

--- a/man/HclustParam-class.Rd
+++ b/man/HclustParam-class.Rd
@@ -71,6 +71,7 @@ If \code{cut.fun=NULL}, \code{cut.dynamic=FALSE} and \code{cut.params} does not 
 \examples{
 clusterRows(iris[,1:4], HclustParam())
 clusterRows(iris[,1:4], HclustParam(method="ward.D2"))
+clusterRows(iris[,1:4], HclustParam(metric = "canberra", dist.fun = vegan::vegdist))
 
 }
 \seealso{

--- a/man/HclustParam-class.Rd
+++ b/man/HclustParam-class.Rd
@@ -13,6 +13,7 @@
 \usage{
 HclustParam(
   metric = NULL,
+  dist.fun = NULL,
   method = NULL,
   cut.fun = NULL,
   cut.dynamic = FALSE,
@@ -26,6 +27,8 @@ HclustParam(
 }
 \arguments{
 \item{metric}{String specifying the distance metric to use in \code{\link{dist}}.}
+
+\item{dist.fun}{Function specifying the function to use to compute the distance matrix.}
 
 \item{method}{String specifying the agglomeration method to use in \code{\link{hclust}}.}
 

--- a/man/HierarchicalParam-class.Rd
+++ b/man/HierarchicalParam-class.Rd
@@ -14,6 +14,7 @@ It causes \code{\link{clusterRows}} to dispatch to clustering algorithms that pr
 
 The virtual class provides \code{metric}, the choice of distance metric.
 This is conventionally passed to \code{\link{dist}} and defaults to a Euclidean distance in most subclasses.
+The distance function can be changed with the parameter \code{dist.fun}.
 
 It also provides a number of slots to manage the final tree cut:
 \itemize{

--- a/man/bluster-package.Rd
+++ b/man/bluster-package.Rd
@@ -14,6 +14,9 @@ Wraps common clustering algorithms in an easily extended S4 framework. Backends 
 Other contributors:
 \itemize{
   \item Stephanie Hicks [contributor]
+  \item Basil Courbayre [contributor]
+  \item Tuomas Borman [contributor]
+  \item Leo Lahti [contributor]
 }
 
 }

--- a/tests/testthat/test-hclust-param.R
+++ b/tests/testthat/test-hclust-param.R
@@ -61,17 +61,16 @@ test_that("clusterRows works with the dynamic tree cut", {
     expect_identical(length(out), nrow(m))
 })
 
-# The following test is only ran when vegan is available
-if (require(vegan)) {
-    test_that("dist.fun parameter works correctly", {
-        m <- matrix(runif(1000), ncol=10)
-        dist_result <- clusterRows(m, HclustParam(metric = "euclidean"))
-        vegdist_result <- clusterRows(m, HclustParam(metric = "euclidean", dist.fun = vegan::vegdist))
-        expect_identical(dist_result, vegdist_result)
-        
-        vegdist_result2 <- clusterRows(m, HclustParam(metric = "canberra", dist.fun = vegan::vegdist), full = TRUE)
-        res_dist_matrix <- vegdist_result2$objects$dist
-        original_dist_matrix <- vegan::vegdist(m, "canberra")
-        expect_setequal(res_dist_matrix, original_dist_matrix)
-    })
-}
+# Vegan-dependant test
+test_that("dist.fun parameter works correctly", {
+    m <- matrix(runif(1000), ncol=10)
+    dist_result <- clusterRows(m, HclustParam(metric = "euclidean"))
+    vegdist_result <- clusterRows(m, HclustParam(metric = "euclidean", dist.fun = vegan::vegdist))
+    expect_identical(dist_result, vegdist_result)
+    
+    vegdist_result2 <- clusterRows(m, HclustParam(metric = "canberra", dist.fun = vegan::vegdist), full = TRUE)
+    res_dist_matrix <- vegdist_result2$objects$dist
+    original_dist_matrix <- vegan::vegdist(m, "canberra")
+    expect_setequal(res_dist_matrix, original_dist_matrix)
+})
+

--- a/tests/testthat/test-hclust-param.R
+++ b/tests/testthat/test-hclust-param.R
@@ -61,3 +61,17 @@ test_that("clusterRows works with the dynamic tree cut", {
     expect_identical(length(out), nrow(m))
 })
 
+# The following test is only ran when vegan is available
+if (require(vegan)) {
+    test_that("dist.fun parameter works correctly", {
+        m <- matrix(runif(1000), ncol=10)
+        dist_result <- clusterRows(m, HclustParam(metric = "euclidean"))
+        vegdist_result <- clusterRows(m, HclustParam(metric = "euclidean", dist.fun = vegan::vegdist))
+        expect_identical(dist_result, vegdist_result)
+        
+        vegdist_result2 <- clusterRows(m, HclustParam(metric = "canberra", dist.fun = vegan::vegdist), full = TRUE)
+        res_dist_matrix <- vegdist_result2$objects$dist
+        original_dist_matrix <- vegan::vegdist(m, "canberra")
+        expect_setequal(res_dist_matrix, original_dist_matrix)
+    })
+}


### PR DESCRIPTION
Hello,

as discussed in the issue https://github.com/LTLA/bluster/issues/13, there is a need for dissimilarity indices used in ecology.

This PR adds `dist.fun` option that can be used to specify dissimilarity function in hierarchical clustering. For example, now it is possible to calculate dissimilarity indices provided by `vegan::vegdist` function. The default choice for dissimilarity function is `stats::dist`.

Please see also the discussion in https://github.com/microbiome/bluster/pull/1

What do you think?

-Tuomas & @BananaCancer